### PR TITLE
replace obsolete URI methods

### DIFF
--- a/lib/pdfkit/source.rb
+++ b/lib/pdfkit/source.rb
@@ -38,11 +38,11 @@ class PDFKit
     private
 
     def shell_safe_url
-      url_needs_escaping? ? URI::escape(@source) : @source
+      url_needs_escaping? ? Addressable::URI::encode(@source) : @source
     end
 
     def url_needs_escaping?
-      URI::decode(@source) == @source
+      CGI::unescape(@source) == @source
     end
   end
 end

--- a/pdfkit.gemspec
+++ b/pdfkit.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.requirements << "wkhtmltopdf"
+  s.requirements << "addressable"
 
   # Development Dependencies
   s.add_development_dependency(%q<activesupport>, [">= 4.1.11"])


### PR DESCRIPTION
В ветке с Консолью (надеюсь, только в ней) у меня перестали генериться PDF, `undefined method `decode' for URI:Module`, потому что в какой-то момент эти методы из модуля URI действительно выпилили